### PR TITLE
Make IP inaccessible to the public

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     image: bennyboomblaster/minitwitimage:latest
     container_name: chirp
     ports:
-      - "7273:7273"
+      - "127.0.0.1:7273:7273"
     environment:
       - "ConnectionStrings__DefaultConnection=Host=db-postgresql-fra1-72367-do-user-33600044-0.e.db.ondigitalocean.com;Port=25060;Database=chirp;Username=doadmin;Password=${POSTGRES_PSW};SSL Mode=Require"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - loki
 
   alloy:
+    platform: linux/amd64
     image: grafana/alloy@sha256:e3a1fff5eee8e2535fb75b350d0ccb722149720c788e57fd8d93b33e9163d85b
     container_name: alloy
     volumes:
@@ -34,6 +35,7 @@ services:
     restart: unless-stopped
 
   loki:
+    platform: linux/amd64
     image: grafana/loki@sha256:535a14ffef1d48099fc7f940da51bbcb253fcc63c6918e070f60caa53c82bf5c
     container_name: loki
     ports:


### PR DESCRIPTION
This PR contains changes that will make chirpitu.live the 'main' page, meaning that it should no longer be possible for outsiders to access Chirp via the IP-address:)