### PR TITLE
Docker swarm

### DIFF
--- a/.github/workflows/Continuous_Deployment_Swarm.yml
+++ b/.github/workflows/Continuous_Deployment_Swarm.yml
@@ -1,0 +1,72 @@
+---
+name: Continuous Deployment (Swarm)
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    manual: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push minitwitimage
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/minitwitimage:latest
+          cache-from: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/minitwitimage:webbuildcache
+          cache-to: type=registry,ref=${{ secrets.DOCKER_USERNAME }}/minitwitimage:webbuildcache,mode=max
+
+      - name: Configure SSH
+        run: |
+          mkdir -p ~/.ssh/
+          echo "$SSH_KEY" > ~/.ssh/do_ssh_key
+          chmod 600 ~/.ssh/do_ssh_key
+        env:
+          SSH_KEY: ${{ secrets.SSH_KEY_SWARM }}
+
+      - name: Copy stack and config files to server
+        run: |
+          scp -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no \
+            chirp_stack.yml $SSH_USER@$SSH_HOST:~/chirp_stack.yml
+          scp -r -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no \
+            grafana $SSH_USER@$SSH_HOST:~/grafana
+          scp -r -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no \
+            monitoring $SSH_USER@$SSH_HOST:~/monitoring
+          scp -r -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no \
+            loki $SSH_USER@$SSH_HOST:~/loki
+          scp -r -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no \
+            alloy $SSH_USER@$SSH_HOST:~/alloy
+        env:
+          SSH_USER: ${{ secrets.SSH_USER_SWARM }}
+          SSH_HOST: ${{ secrets.SSH_HOST_SWARM }}
+
+      - name: Deploy to swarm
+        run: |
+          ssh $SSH_USER@$SSH_HOST -i ~/.ssh/do_ssh_key -o StrictHostKeyChecking=no \
+            "docker login -u '$DOCKER_USERNAME' -p '$DOCKER_PASSWORD' && \
+             export POSTGRES_PSW='$POSTGRES_PSW' && \
+             docker stack deploy -c ~/chirp_stack.yml chirp --with-registry-auth && \
+             docker service update --image $DOCKER_USERNAME/minitwitimage:latest chirp_chirpserver --with-registry-auth"
+        env:
+          SSH_USER: ${{ secrets.SSH_USER_SWARM }}
+          SSH_HOST: ${{ secrets.SSH_HOST_SWARM }}
+          POSTGRES_PSW: ${{ secrets.POSTGRES_PSW }}
+          DOCKER_USERNAME: ${{ secrets.DOCKER_USERNAME }}
+          DOCKER_PASSWORD: ${{ secrets.DOCKER_PASSWORD }}

--- a/.gitignore
+++ b/.gitignore
@@ -487,4 +487,4 @@ ehthumbs_vista.db
 *.hcl
 *.backup
 secrets
-ssk_key/
+ssh_key/

--- a/.gitignore
+++ b/.gitignore
@@ -479,3 +479,12 @@ ehthumbs_vista.db
 *.db
 *.db-shm
 *.db-wal
+
+
+#Terraform file
+*.terraform
+*.tfstate
+*.hcl
+*.backup
+secrets
+ssk_key/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,83 @@
 The Chirp! URL: http://142.93.169.145:7273
+
+## Deploying with Terraform and Docker Swarm
+
+### Prerequisites
+
+- [Terraform](https://developer.hashicorp.com/terraform/downloads) (>= 1.3.0)
+- `jq` installed locally (`sudo apt install jq`)
+- Access to the team's DigitalOcean account
+
+### Step 1: Generate SSH keys
+
+```bash
+mkdir -p ssh_key
+ssh-keygen -t ed25519 -f ssh_key/terraform -N ""
+```
+
+This creates `ssh_key/terraform` (private) and `ssh_key/terraform.pub` (public). Do not commit these to git.
+
+### Step 2: Create a secrets file
+
+Create a file called `secrets` in the project root:
+
+```bash
+export TF_VAR_do_token=<your-digitalocean-api-token>
+export TF_VAR_postgres_psw=<the-database-password>
+```
+
+| Variable | Where to find it |
+|---|---|
+| `TF_VAR_do_token` | DigitalOcean console > API > Tokens > Generate New Token (read + write) |
+| `TF_VAR_postgres_psw` | Ask a team member or find it in the DigitalOcean database connection details |
+
+Do not commit the `secrets` file to git.
+
+### Step 3: Create a Reserved IP
+
+1. Go to DigitalOcean console > **Networking** > **Reserved IPs**
+2. Click **Assign Reserved IP** and select region `fra1`
+3. Copy the IP address
+4. Pass it when running apply:
+   ```bash
+   terraform apply -var="reserved_ip=<your-reserved-ip>"
+   ```
+
+### Step 4: Deploy
+
+```bash
+source secrets
+terraform init
+terraform apply
+```
+
+Terraform will:
+1. Upload your SSH key to DigitalOcean
+2. Create a droplet running Docker
+3. Copy all config files (stack, Prometheus, Grafana, Loki, Alloy)
+4. Initialize a Docker Swarm cluster
+5. Deploy all services via `docker stack deploy`
+6. Whitelist the droplet on the managed database
+7. Assign the reserved IP to the droplet
+
+### Accessing the server
+
+```bash
+ssh -i ssh_key/terraform root@<your-reserved-ip>
+```
+
+### Useful commands on the server
+
+```bash
+docker service ls                      # list all services and their status
+docker service logs chirp_chirpserver  # view app logs
+docker service ps chirp_chirpserver    # see which nodes run the app
+```
+
+### Tearing down
+
+```bash
+terraform destroy
+```
+
+This destroys the droplet but keeps the reserved IP (it is managed outside Terraform).

--- a/chirp_stack.yml
+++ b/chirp_stack.yml
@@ -1,0 +1,129 @@
+version: "3.8"
+
+services:
+  chirpserver:
+    image: bennyboomblaster/minitwitimage:latest
+
+    ports:
+      - target: 7273
+        published: 7273
+        protocol: tcp
+        mode: ingress
+
+    environment:
+      - ConnectionStrings__DefaultConnection=Host=db-postgresql-fra1-72367-do-user-33600044-0.e.db.ondigitalocean.com;Port=25060;Database=chirp;Username=doadmin;Password=${POSTGRES_PSW};SSL Mode=Require
+
+    volumes:
+      - ./latest.txt:/app/data/latest.txt
+
+    networks:
+      - itu-minitwit-network
+
+    deploy:
+      replicas: 2
+      restart_policy:
+        condition: on-failure
+
+  alloy:
+    image: grafana/alloy@sha256:e3a1fff5eee8e2535fb75b350d0ccb722149720c788e57fd8d93b33e9163d85b
+
+    command: run --server.http.listen-addr=0.0.0.0:4000 --storage.path=/var/lib/alloy/data /etc/alloy/config.alloy
+
+    ports:
+      - target: 4000
+        published: 4000
+        protocol: tcp
+        mode: ingress
+
+    volumes:
+      - ./alloy/config.alloy:/etc/alloy/config.alloy:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+
+    networks:
+      - itu-minitwit-network
+
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: on-failure
+
+  loki:
+    image: grafana/loki@sha256:535a14ffef1d48099fc7f940da51bbcb253fcc63c6918e070f60caa53c82bf5c
+
+    command: -config.file=/etc/loki/loki-config.yml
+
+    ports:
+      - target: 3100
+        published: 3100
+        protocol: tcp
+        mode: ingress
+
+    volumes:
+      - ./loki/loki-config.yml:/etc/loki/loki-config.yml
+      - loki-data:/loki
+
+    networks:
+      - itu-minitwit-network
+
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: on-failure
+
+  prometheus:
+    image: prom/prometheus@sha256:4a61322ac1103a0e3aea2a61ef1718422a48fa046441f299d71e660a3bc71ae9
+
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+
+    ports:
+      - target: 9090
+        published: 9090
+        protocol: tcp
+        mode: ingress
+
+    volumes:
+      - ./monitoring/prometheus.yml:/etc/prometheus/prometheus.yml
+
+    networks:
+      - itu-minitwit-network
+
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: on-failure
+
+  grafana:
+    image: grafana/grafana@sha256:7227fe2aca02ad399c8de438ceaae7687415da2abc763665795858edbe48819c
+
+    ports:
+      - target: 3000
+        published: 3000
+        protocol: tcp
+        mode: ingress
+
+    environment:
+      - GF_SECURITY_ADMIN_USER=helgeandfriends
+      - GF_SECURITY_ADMIN_PASSWORD=sesame0uvr3toi
+      - GF_USERS_ALLOW_SIGN_UP=false
+
+    volumes:
+      - ./grafana/datasource.yml:/etc/grafana/provisioning/datasources/datasource.yml
+      - ./grafana/dashboards:/etc/grafana/provisioning/dashboards
+      - grafana-storage:/var/lib/grafana
+
+    networks:
+      - itu-minitwit-network
+
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: on-failure
+
+networks:
+  itu-minitwit-network:
+    driver: overlay
+
+volumes:
+  grafana-storage:
+  loki-data:

--- a/chirp_swarm_cluster.tf
+++ b/chirp_swarm_cluster.tf
@@ -1,0 +1,222 @@
+terraform {
+  required_version = ">= 1.3.0"
+
+  required_providers {
+    digitalocean = {
+      source  = "digitalocean/digitalocean"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "digitalocean" {
+  token = var.do_token
+}
+
+#####################################
+# VARIABLES
+#####################################
+
+variable "do_token" {
+  sensitive = true
+}
+
+variable "region" {
+  default = "fra1"
+}
+
+variable "ssh_public_key" {
+  default = "ssh_key/terraform.pub"
+}
+
+variable "ssh_private_key" {
+  default = "ssh_key/terraform"
+}
+
+variable "postgres_psw" {}
+
+variable "db_cluster_id" {
+  description = "DigitalOcean managed database cluster ID"
+  default     = "f9289e58-03ef-4e82-8523-c3ca3dfd873d"
+}
+
+variable "reserved_ip" {
+  description = "Pre-existing DigitalOcean reserved IP address"
+  default     = "209.38.190.12"
+}
+
+#####################################
+# SSH KEY
+#####################################
+
+resource "digitalocean_ssh_key" "default" {
+  name       = "terraform-key"
+  public_key = file(var.ssh_public_key)
+}
+
+#####################################
+# SINGLE NODE SWARM MANAGER
+#####################################
+
+resource "digitalocean_droplet" "swarm" {
+  name   = "chirp-swarm"
+  region = var.region
+  size   = "s-1vcpu-1gb"
+  image  = "docker-20-04"
+
+  ssh_keys = [
+    digitalocean_ssh_key.default.fingerprint
+  ]
+
+  connection {
+    type        = "ssh"
+    user        = "root"
+    host        = self.ipv4_address
+    private_key = file(var.ssh_private_key)
+    timeout     = "3m"
+  }
+
+  #####################################
+  # COPY STACK FILES
+  #####################################
+
+  provisioner "file" {
+    source      = "chirp_stack.yml"
+    destination = "/root/chirp_stack.yml"
+  }
+
+#provisioner "file" {
+#  source      = "stack/nginx/default.conf"
+#  destination = "/root/nginx/default.conf"
+#}
+
+  provisioner "file" {
+    source      = "monitoring/prometheus.yml"
+    destination = "/root/prometheus.yml"
+  }
+
+  provisioner "file" {
+    source      = "alloy/config.alloy"
+    destination = "/root/config.alloy"
+  }
+
+  provisioner "file" {
+    source      = "loki/loki-config.yml"
+    destination = "/root/loki-config.yml"
+  }
+
+  provisioner "file" {
+    source      = "grafana/datasource.yml"
+    destination = "/root/datasource.yml"
+  }
+
+  provisioner "file" {
+    source      = "grafana/dashboards"
+    destination = "/root/dashboards"
+  }
+
+  provisioner "file" {
+    source      = "latest.txt"
+    destination = "/root/latest.txt"
+  }
+
+    #####################################
+    # SETUP + DEPLOY
+    #####################################
+
+    provisioner "remote-exec" {
+    inline = [
+        # firewall
+        "ufw allow 22",
+        "ufw allow 80",
+        "ufw allow 3000",
+        "ufw allow 3100",
+        "ufw allow 4000",
+        "ufw allow 7273",
+        "ufw allow 9090",
+        "ufw allow 2377/tcp",
+        "ufw allow 7946",
+        "ufw allow 4789/udp",
+        "ufw --force enable",
+
+        # prepare folders
+        "mkdir -p /root/monitoring",
+        "mkdir -p /root/alloy",
+        "mkdir -p /root/loki",
+        "mkdir -p /root/grafana/dashboards",
+
+        # move files into expected locations
+        "mv /root/prometheus.yml /root/monitoring/prometheus.yml",
+        "mv /root/config.alloy /root/alloy/config.alloy",
+        "mv /root/loki-config.yml /root/loki/loki-config.yml",
+        "mv /root/datasource.yml /root/grafana/datasource.yml",
+        "mv /root/dashboards/* /root/grafana/dashboards/",
+
+        # initialize swarm
+        "docker swarm init --advertise-addr ${self.ipv4_address}",
+
+        # deploy stack with postgres password
+        "POSTGRES_PSW='${var.postgres_psw}' docker stack deploy -c /root/chirp_stack.yml chirp"
+    ]
+    }
+}
+
+#####################################
+# DATABASE FIREWALL (append-only)
+#####################################
+
+resource "null_resource" "db_whitelist" {
+  triggers = {
+    droplet_id = digitalocean_droplet.swarm.id
+  }
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      CURRENT=$(curl -s -X GET \
+        -H "Authorization: Bearer ${var.do_token}" \
+        "https://api.digitalocean.com/v2/databases/${var.db_cluster_id}/firewall" \
+        | jq '.rules')
+
+      NEW_RULES=$(echo "$CURRENT" | jq '. + [{"type": "droplet", "value": "${digitalocean_droplet.swarm.id}"}]')
+
+      curl -s -X PUT \
+        -H "Authorization: Bearer ${var.do_token}" \
+        -H "Content-Type: application/json" \
+        -d "{\"rules\": $NEW_RULES}" \
+        "https://api.digitalocean.com/v2/databases/${var.db_cluster_id}/firewall"
+    EOT
+  }
+}
+
+#####################################
+# RESERVED (FLOATING) IP
+#####################################
+
+resource "digitalocean_reserved_ip_assignment" "chirp" {
+  ip_address = var.reserved_ip
+  droplet_id = digitalocean_droplet.swarm.id
+}
+
+#####################################
+# OUTPUTS
+#####################################
+
+output "server_ip" {
+  value = digitalocean_droplet.swarm.ipv4_address
+}
+
+output "reserved_ip" {
+  value = var.reserved_ip
+}
+
+output "website" {
+  value = "http://${var.reserved_ip}"
+}
+
+output "grafana" {
+  value = "http://${var.reserved_ip}:3000"
+}
+
+output "prometheus" {
+  value = "http://${var.reserved_ip}:9090"
+}


### PR DESCRIPTION
  - Adds Terraform configuration to provision a DigitalOcean droplet and deploy Chirp as a Docker Swarm stack with rolling updates                                                      
  - Includes Docker stack file (chirp_stack.yml) with all services: Chirp (2 replicas), Prometheus, Grafana, Loki, and Alloy
  - Adds a new GitHub Actions workflow for continuous deployment to the swarm                                                                                                           
  - Automates database firewall whitelisting and reserved IP assignment via Terraform                                                                                                   
  - Adds deployment guide to README 