### PR TITLE
Fix XSS vulnerabilities in search query handling

### DIFF
--- a/src/Chirp.Web/Pages/Public.cshtml
+++ b/src/Chirp.Web/Pages/Public.cshtml
@@ -89,7 +89,7 @@
             }
             <span>Page @currentPage</span>
 
-            <a id="next" href="/?pageIndex=@(currentPage + 1)&search=@Request.Query["search"]">Next</a>
+            <a id="next" href="/?pageIndex=@(currentPage + 1)&search=@safeSearch">Next</a>
         </div>
     }
     else

--- a/src/Chirp.Web/Pages/Public.cshtml
+++ b/src/Chirp.Web/Pages/Public.cshtml
@@ -63,12 +63,12 @@
 
                                 var isSaved = await Model.IsSavedAsync(cheep);
                                 if (isSaved) {
-                                    <form method="post" asp-page-handler="RemoveSave" asp-route-search="@Request.Query["search"]" asp-route-pageIndex="@Model.PageIndex"  style="display:inline;">
+                                    <form method="post" asp-page-handler="RemoveSave" asp-route-search="@safeSearch" asp-route-pageIndex="@Model.PageIndex"  style="display:inline;">
                                         <button type="submit" class="btn btn-link p-0" name="unsave"
                                             value="@cheep.CheepId">unsave</button>
                                     </form>
                                 } else {
-                                    <form method="post" asp-page-handler="Save" asp-route-search="@Request.Query["search"]" asp-route-pageIndex="@Model.PageIndex"  style="display:inline;">
+                                    <form method="post" asp-page-handler="Save" asp-route-search="@safeSearch" asp-route-pageIndex="@Model.PageIndex"  style="display:inline;">
                                         <button type="submit" class="btn btn-link p-0" name="save"
                                             value="@cheep.CheepId">save</button>
                                     </form>

--- a/src/Chirp.Web/Pages/Public.cshtml
+++ b/src/Chirp.Web/Pages/Public.cshtml
@@ -98,7 +98,7 @@
         <br/>
         @if (currentPage > 1)
         {
-            <a href="/?pageIndex=@(currentPage - 1)&search=@Request.Query["search"]">Prev</a>
+            <a href="/?pageIndex=@(currentPage - 1)&search=@safeSearch">Prev</a>
         }
         <span>Page @currentPage</span>
     }

--- a/src/Chirp.Web/Pages/Public.cshtml
+++ b/src/Chirp.Web/Pages/Public.cshtml
@@ -48,7 +48,7 @@
                                 var isFollowing = await Model.IsFollowingAsync(User.Identity.Name!, cheep.Author.Name);
                                 if (isFollowing)
                                 {
-                                    <form method="post" asp-page-handler="Unfollow" asp-route-search="@Request.Query["search"]" asp-route-pageIndex="@Model.PageIndex" style="display:inline;">
+                                    <form method="post" asp-page-handler="Unfollow" asp-route-search="@safeSearch" asp-route-pageIndex="@Model.PageIndex" style="display:inline;">
                                         <button type="submit" class="btn btn-link p-0" name="unfollow"
                                             value="@cheep.Author.Name">unfollow</button>
                                     </form>

--- a/src/Chirp.Web/Pages/Public.cshtml
+++ b/src/Chirp.Web/Pages/Public.cshtml
@@ -85,7 +85,7 @@
         <div class="pagination">
             @if (currentPage > 1)
             {
-                <a href="/?pageIndex=@(currentPage - 1)&search=@Request.Query["search"]">Prev</a>
+                <a href="/?pageIndex=@(currentPage - 1)&search=@safeSearch">Prev</a>
             }
             <span>Page @currentPage</span>
 

--- a/src/Chirp.Web/Pages/Public.cshtml
+++ b/src/Chirp.Web/Pages/Public.cshtml
@@ -5,6 +5,7 @@
     Layout = "Shared/_Layout";
     int currentPage = 1;
     var pageQuery = Model.HttpContext.Request.Query["pageIndex"];
+    var safeSearch = System.Net.WebUtility.HtmlEncode(Request.Query["search"].ToString());
     if (!string.IsNullOrEmpty(pageQuery))
     {
         int.TryParse(pageQuery, out currentPage);

--- a/src/Chirp.Web/Pages/Public.cshtml
+++ b/src/Chirp.Web/Pages/Public.cshtml
@@ -55,7 +55,7 @@
                                 }
                                 else
                                 {
-                                    <form method="post" asp-page-handler="Follow" asp-route-search="@Request.Query["search"]" asp-route-pageIndex="@Model.PageIndex"  style="display:inline;">
+                                    <form method="post" asp-page-handler="Follow" asp-route-search="@safeSearch" asp-route-pageIndex="@Model.PageIndex"  style="display:inline;">
                                         <button type="submit" class="btn btn-link p-0" name="follow"
                                             value="@cheep.Author.Name">follow</button>
                                     </form>

--- a/src/Chirp.Web/Pages/Saved.cshtml
+++ b/src/Chirp.Web/Pages/Saved.cshtml
@@ -61,11 +61,11 @@
         <div class="pagination">
             @if (currentPage > 1)
             {
-                <a href="/Saved/?pageIndex=@(currentPage - 1)&search=@Request.Query["search"]">Prev</a>
+                <a href="/Saved/?pageIndex=@(currentPage - 1)&search=@safeSearch">Prev</a>
             }
             <span>Page @currentPage</span>
 
-            <a href="/Saved/?pageIndex=@(currentPage + 1)&search=@Request.Query["search"]">Next</a>
+            <a href="/Saved/?pageIndex=@(currentPage + 1)&search=@safeSearch">Next</a>
         </div>
     }
     else
@@ -74,7 +74,7 @@
         <br/>
         @if (currentPage > 1)
         {
-            <a href="/Saved/?pageIndex=@(currentPage - 1)&search=@Request.Query["search"]">Prev</a>
+            <a href="/Saved/?pageIndex=@(currentPage - 1)&search=@safeSearch">Prev</a>
         }
         <span>Page @currentPage</span>
     }

--- a/src/Chirp.Web/Pages/Saved.cshtml
+++ b/src/Chirp.Web/Pages/Saved.cshtml
@@ -33,20 +33,20 @@
                                 var isFollowing = await Model.IsFollowingAsync(User.Identity.Name!, cheep.Author.Name);
                                 if (isFollowing)
                                 {
-                                    <form method="post" asp-page-handler="Unfollow" asp-route-search="@Request.Query["search"]" asp-route-pageIndex="@Model.PageIndex" style="display:inline;">
+                                    <form method="post" asp-page-handler="Unfollow" asp-route-search="@safeSearch" asp-route-pageIndex="@Model.PageIndex" style="display:inline;">
                                         <button type="submit" class="btn btn-link p-0" name="unfollow"
                                             value="@cheep.Author.Name">unfollow</button>
                                     </form>
                                 }
                                 else
                                 {
-                                    <form method="post" asp-page-handler="Follow" asp-route-search="@Request.Query["search"]" asp-route-pageIndex="@Model.PageIndex" style="display:inline;">
+                                    <form method="post" asp-page-handler="Follow" asp-route-search="@safeSearch" asp-route-pageIndex="@Model.PageIndex" style="display:inline;">
                                         <button type="submit" class="btn btn-link p-0" name="follow"
                                             value="@cheep.Author.Name">follow</button>
                                     </form>
                                 }
 
-                                <form method="post" asp-page-handler="RemoveSave" asp-route-search="@Request.Query["search"]" asp-route-pageIndex="@Model.PageIndex" style="display:inline;">
+                                <form method="post" asp-page-handler="RemoveSave" asp-route-search="@safeSearch" asp-route-pageIndex="@Model.PageIndex" style="display:inline;">
                                     <button type="submit" class="btn btn-link p-0" name="unsave"
                                         value="@cheep.CheepId">unsave</button>
                                 </form>

--- a/src/Chirp.Web/Pages/Saved.cshtml
+++ b/src/Chirp.Web/Pages/Saved.cshtml
@@ -5,6 +5,7 @@
     Layout = "Shared/_Layout";
     int currentPage = 1;
     var pageQuery = Model.HttpContext.Request.Query["pageIndex"];
+    var safeSearch = System.Net.WebUtility.HtmlEncode(Request.Query["search"].ToString());
     if (!string.IsNullOrEmpty(pageQuery))
     {
         int.TryParse(pageQuery, out currentPage);

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml
@@ -92,7 +92,7 @@
         <br/>
         @if (currentPage > 1)
         {
-            <a href="/?pageIndex=@(currentPage - 1)&search="@safeSearch"">Prev</a>
+            <a href="/?pageIndex=@(currentPage - 1)&search=@safeSearch">Prev</a>
         }
         <span>Page @currentPage</span>
     }

--- a/src/Chirp.Web/Pages/UserTimeline.cshtml
+++ b/src/Chirp.Web/Pages/UserTimeline.cshtml
@@ -6,6 +6,7 @@
     var routeName = HttpContext.GetRouteValue("author");
     int currentPage = 1;
     var pageQuery = Model.HttpContext.Request.Query["pageIndex"];
+    var safeSearch = System.Net.WebUtility.HtmlEncode(Request.Query["search"].ToString());
     if (!string.IsNullOrEmpty(pageQuery))
     {
         int.TryParse(pageQuery, out currentPage);
@@ -19,7 +20,7 @@
     {
         <div class="cheepbox">
             <h3>What's on your mind @(User.Identity!.Name)?</h3>
-            <form method="post" asp-page-handler="Cheep" asp-route-search="@Request.Query["search"]" asp-route-pageIndex="@Model.PageIndex">
+            <form method="post" asp-page-handler="Cheep" asp-route-search="@safeSearch" asp-route-pageIndex="@Model.PageIndex">
                 <input required data-val="true" data-val-required="The Message field is required." pattern=".*\S.*"  style="float: left" type="text" asp-for="Text">
                 <input type="submit" value="Share">
             </form>
@@ -40,26 +41,26 @@
                                     var isFollowing = await Model.IsFollowingAsync(User.Identity.Name!, cheep.Author.Name);
                                     if (isFollowing)
                                     {
-                                    <form method="post" asp-page-handler="Unfollow" asp-route-search="@Request.Query["search"]" asp-route-pageIndex="@Model.PageIndex" style="display:inline;">
+                                    <form method="post" asp-page-handler="Unfollow" asp-route-search="@safeSearch" asp-route-pageIndex="@Model.PageIndex" style="display:inline;">
                                         <button type="submit" class="btn btn-link p-0" name="unfollow"
                                                 value="@cheep.Author.Name">unfollow</button>
                                     </form>
                                     }
                                     else
                                     {
-                                    <form method="post" asp-page-handler="Follow" asp-route-search="@Request.Query["search"]" asp-route-pageIndex="@Model.PageIndex" style="display:inline;">
+                                    <form method="post" asp-page-handler="Follow" asp-route-search="@safeSearch" asp-route-pageIndex="@Model.PageIndex" style="display:inline;">
                                         <button type="submit" class="btn btn-link p-0" name="follow"
                                                 value="@cheep.Author.Name">follow</button>
                                     </form>
                                     }
                                      var isSaved = await Model.IsSavedAsync(cheep);
                                     if (isSaved) {
-                                        <form method="post" asp-page-handler="RemoveSave" asp-route-search="@Request.Query["search"]" asp-route-pageIndex="@Model.PageIndex" style="display:inline;">
+                                        <form method="post" asp-page-handler="RemoveSave" asp-route-search="@safeSearch" asp-route-pageIndex="@Model.PageIndex" style="display:inline;">
                                             <button type="submit" class="btn btn-link p-0" name="unsave"
                                                 value="@cheep.CheepId">unsave</button>
                                         </form>
                                     } else {
-                                        <form method="post" asp-page-handler="Save" asp-route-search="@Request.Query["search"]" asp-route-pageIndex="@Model.PageIndex" style="display:inline;">
+                                        <form method="post" asp-page-handler="Save" asp-route-search="@safeSearch" asp-route-pageIndex="@Model.PageIndex" style="display:inline;">
                                             <button type="submit" class="btn btn-link p-0" name="save"
                                                 value="@cheep.CheepId">save</button>
                                         </form>
@@ -91,7 +92,7 @@
         <br/>
         @if (currentPage > 1)
         {
-            <a href="/?pageIndex=@(currentPage - 1)&search=@Request.Query["search"]">Prev</a>
+            <a href="/?pageIndex=@(currentPage - 1)&search="@safeSearch"">Prev</a>
         }
         <span>Page @currentPage</span>
     }


### PR DESCRIPTION
CodeQL identified cross-site scripting vulnerabilities where raw Request.Query["search"] were being handeled without sanitation

Fix by encoding the search query using System.Net.WebUtility.HtmlEncode() as a safeSearch variable at the top of each affected page, then replacing all raw Request.Query["search"] references with safeSearch.
